### PR TITLE
added call to os.chdir if os.path.curdir is not the top level dir

### DIFF
--- a/application.py
+++ b/application.py
@@ -13,6 +13,10 @@ from rsted.pdf import rst2pdf as _rst2pdf
 from flaskext.redis import RedisManager
 from flaskext.helpers import render_html
 
+# handle relative path references by changing to project directory
+run_from = os.path.dirname(os.path.abspath(sys.argv[0]))
+if run_from != os.path.curdir:
+    os.chdir(run_from)
 
 # create our little application :)
 app = Flask(__name__)


### PR DESCRIPTION
Without this, if the application.py is launched from a directory other than the directory housing application.py, you will receive a large traceback based on IOErrors.

Namely call from rsted/html, line 34, in rst2html

it cannot find the var/themes/template.txt file
