### PR TITLE
use script_root in absolute links to support subdirectory URLs

### DIFF
--- a/static/scripts/editor.js
+++ b/static/scripts/editor.js
@@ -7,7 +7,7 @@ function getSelectedTheme() {
             theme = this.value;
             return false;
         }
-    })
+    });
     return theme;
 }
 
@@ -101,7 +101,7 @@ function genPreview() {
     }
     lastContent = rstContent;
     activeXhr = $.ajax({
-        'url': '/srv/rst2html/',
+        'url': script_root + '/srv/rst2html/',
         'data': {'rst': rstContent, 'theme': getSelectedTheme()},
         'type': 'POST',
         'error': function(xhr) {
@@ -119,9 +119,9 @@ var timerId = null;
 
 function getCurrentLink(res) {
     if (!res) {
-        return 'http://' + window.location.host + '/?theme=' + getSelectedTheme();
+        return '//' + window.location.host + script_root + '/?theme=' + getSelectedTheme();
     }
-    return 'http://' + window.location.host + '/?n=' + res + '&theme=' + getSelectedTheme();
+    return '//' + window.location.host + script_root + '/?n=' + res + '&theme=' + getSelectedTheme();
 }
 
 function adjustBrowse() {
@@ -153,7 +153,7 @@ $(function() {
     $('#save_link').click(function(e) {
 
         $.ajax({
-            'url': '/srv/save_rst/',
+            'url': script_root + '/srv/save_rst/',
             'type': 'POST',
             'data': {'rst': $('textarea#editor').val()},
             'success': function(response) {
@@ -169,7 +169,7 @@ $(function() {
 
     $('#del_link').click(function(e) {
         $.ajax({
-            'url': '/srv/del_rst/',
+            'url': script_root + '/srv/del_rst/',
             'type': 'GET',
             'data': {'n': getCurrentDocument()},
             'success': function(response) {

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,16 +5,16 @@
         <meta charset="UTF-8">
         <title>{% block title %}Online reStructuredText editor{% endblock %}</title>
 
-        <link rel="stylesheet" href="{{ MEDIA_URL }}style/base.css"/>
-        <link rel="stylesheet" href="{{ MEDIA_URL }}style/site.css"/>
-        <link rel="stylesheet" href="{{ MEDIA_URL }}style/menu.css"/>
+	<link rel="stylesheet" href="{{ request.script_root }}{{ MEDIA_URL }}style/base.css"/>
+	<link rel="stylesheet" href="{{ request.script_root }}{{ MEDIA_URL }}style/site.css"/>
+	<link rel="stylesheet" href="{{ request.script_root }}{{ MEDIA_URL }}style/menu.css"/>
 
-        <link rel="stylesheet" href="{{ MEDIA_URL }}style/overcast/jquery-ui-1.8.16.custom.css" />
+	<link rel="stylesheet" href="{{ request.script_root }}{{ MEDIA_URL }}style/overcast/jquery-ui-1.8.16.custom.css" />
 
 
-        <script src="{{ MEDIA_URL }}scripts/jquery-1.6.4.min.js"></script>
-        <script src="{{ MEDIA_URL }}scripts/jquery-ui-1.8.16.custom.min.js"></script>
-        <script src="{{ MEDIA_URL }}scripts/jquery.layout.min-1.2.0.js"></script>
+	<script src="{{ request.script_root }}{{ MEDIA_URL }}scripts/jquery-1.6.4.min.js"></script>
+	<script src="{{ request.script_root }}{{ MEDIA_URL }}scripts/jquery-ui-1.8.16.custom.min.js"></script>
+	<script src="{{ request.script_root }}{{ MEDIA_URL }}scripts/jquery.layout.min-1.2.0.js"></script>
 
         {% endblock %}
     </head>
@@ -35,6 +35,7 @@
             </menu>
         </header>
         <script type="text/javascript">
+            var script_root = {{ request.script_root|tojson|safe }};
             $('#navigation').find("li.active a").click(function(evt) {
                  evt.preventDefault();
              });

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,13 +2,13 @@
 
 {% block head %}
     {{ super() }}
-	<script type="text/javascript" src="{{ MEDIA_URL }}markit/jquery.markitup.js"></script>
-	<script type="text/javascript" src="{{ MEDIA_URL }}markit/sets/rest/set.js"></script>
+    <script type="text/javascript" src="{{ request.script_root }}{{ MEDIA_URL }}markit/jquery.markitup.js"></script>
+    <script type="text/javascript" src="{{ request.script_root }}{{ MEDIA_URL }}markit/sets/rest/set.js"></script>
 
-<link rel="stylesheet" type="text/css" href="{{ MEDIA_URL }}markit/skins/simple/style.css" />
-<link rel="stylesheet" type="text/css" href="{{ MEDIA_URL }}markit/sets/rest/style.css" />
+    <link rel="stylesheet" type="text/css" href="{{ request.script_root }}{{ MEDIA_URL }}markit/skins/simple/style.css" />
+    <link rel="stylesheet" type="text/css" href="{{ request.script_root }}{{ MEDIA_URL }}markit/sets/rest/style.css" />
 
-<script type="text/javascript" src="{{ MEDIA_URL }}scripts/editor.js"></script>
+    <script type="text/javascript" src="{{ request.script_root }}{{ MEDIA_URL }}scripts/editor.js"></script>
 
 <script type="text/javascript">
     var js_params = {{ js_params|tojson|safe }};
@@ -64,13 +64,13 @@
         </div>
 
 
-        <iframe src="/srv/rst2html/" id="browse"></iframe>
+	<iframe src="{{ request.script_root }}/srv/rst2html/" id="browse"></iframe>
     </div>
 </div>
 
 </div>
 
-<form id="save_as_pdf" method="POST" action="/srv/rst2pdf/">
+<form id="save_as_pdf" method="POST" action="{{ request.script_root }}/srv/rst2pdf/">
     <input type="hidden" id="as_pdf_rst" name="rst" />
     <input type="hidden" id="as_pdf_theme" name="theme"/>
 </form>


### PR DESCRIPTION
Hi, 

we needed to install rsted in a sublocation ( foo.com/rsted/ ) and with https enabled. So I did a few changes:
- Change Templates to use `request.script_root` in absolute paths
- Set `request.script_root` as a Javascript variable `script_root` in global context in `base.html`
- Use `script_root` for URLs generated in Javascript
- Use `//...` instead of `http://..` to make links protocol agnostic and support https. 

Our Nginx configuration for running rsted as `/rsted/` using uWSGI looks like this:

```
    location /rsted {
                include uwsgi_params;
                uwsgi_pass unix:/run/uwsgi/app/rsted/socket;
                uwsgi_param SCRIPT_NAME /rsted;
                uwsgi_modifier1 30;
    }
```

Thanks for that awesome piece of software. 
