### PR TITLE
This adds the button to export the document as PDF

### DIFF
--- a/rsted/pdf.py
+++ b/rsted/pdf.py
@@ -3,6 +3,7 @@ import codecs
 utf8codec = codecs.lookup('utf-8')
 
 from flask import current_app
+from flask import request
 
 try:
     from cStringIO import StringIO
@@ -13,6 +14,9 @@ def rst2pdf(content, theme=None):
     topdf = RstToPdf(basedir=current_app.config.root_path, breaklevel=0)
 
     buf = StringIO()
+
+    content = request.form['text']
+
     if not content:
         content = '\0'
     content_utf8 = utf8codec.encode(content)[0]

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,7 +36,7 @@
 {% block content %}
 <div class="b_page_cont">
     <div class="b_page_left">
-        <textarea id="editor" rows="15">{{ rst }}</textarea>
+        <textarea id="editor" rows="15" name="text" form="save_as_pdf">{{ rst }}</textarea>
     </div>
     <div class="b_page_right">
         <div class="right_nav">
@@ -45,15 +45,16 @@
                 <input id="t_nature" type="radio" value="nature" name="style"/><label for="t_nature">Nature</label>
             </div>
         </div>
+        <div class="right">
+            <form id="save_as_pdf" method="POST" action="{{ request.script_root }}/srv/rst2pdf/">
+                <input type="submit" id="as_pdf_rst" name="rst" value="Export to PDF"/>
+                <input type="hidden" id="as_pdf_theme" name="theme"/>
+            </form>
+        </div>
 	    <iframe src="{{ request.script_root }}/srv/rst2html/" id="browse"></iframe>
     </div>
 </div>
 
 </div>
-
-<form id="save_as_pdf" method="POST" action="{{ request.script_root }}/srv/rst2pdf/">
-    <input type="hidden" id="as_pdf_rst" name="rst" />
-    <input type="hidden" id="as_pdf_theme" name="theme"/>
-</form>
 
 {% endblock %}


### PR DESCRIPTION
This addresses the issue #28 

I have used the code that was already present in the `templates/index.html` and made it to submit
the `textarea` to the `rsted/pdf.py`. 

I am using flask's [`request`](http://flask.pocoo.org/docs/0.12/api/#flask.request) from flask to retrieve the data
of the form.
```
content = request.form['text']
```

This change doesn't effect any other aspect of the application.

I am open to any kind of feedback.

спасибо