### PR TITLE
Fork me button css tweaks

### DIFF
--- a/static/style/base.css
+++ b/static/style/base.css
@@ -112,36 +112,16 @@ li.ext_link {
     font-size: 0.9em !important;
 }
 
-a#github-ribbon {
-  position: fixed;
-  top: -5px;
-  right: 5px;
-  width: 150px;
-  line-height: 1;
-  padding: 8px 5px 5px;
-  color: white;
-
-  /* From colorzilla gradient generator */
-  background: #444444; /* Old browsers */
-  background: -moz-linear-gradient(top, #444444 0%, #666666 50%, #444444 100%); /* FF3.6+ */
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#444444), color-stop(50%,#666666), color-stop(100%,#444444)); /* Chrome,Safari4+ */
-  background: -webkit-linear-gradient(top, #444444 0%,#666666 50%,#444444 100%); /* Chrome10+,Safari5.1+ */
-  background: -o-linear-gradient(top, #444444 0%,#666666 50%,#444444 100%); /* Opera11.10+ */
-  background: -ms-linear-gradient(top, #444444 0%,#666666 50%,#444444 100%); /* IE10+ */
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#444444', endColorstr='#444444',GradientType=0 ); /* IE6-9 */
-  background: linear-gradient(top, #444444 0%,#666666 50%,#444444 100%); /* W3C */
-
-  text-shadow: #333 1px 1px 1px; 
-  text-align: center;
+#github-ribbon {
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+  height: 2.5rem;
+  line-height: 2.5rem;
+  padding: 0 1rem;
+  color: #213A49;
+  background: #E1EAEF;
   text-decoration: none;
   font-weight: bold;
-  -webkit-border-radius: 5px;
-  -moz-border-radius: 5px;
-  border-radius: 5px;
-  -webkit-box-shadow: 0px 0px 10px #213A49; /* 94*3 */
-  -moz-box-shadow: 0px 0px 10px #213A49;
-  box-shadow: 0px 0px 10px #213A49;
-  z-index: 1;
+  border-radius: 2px;
 }
-
-


### PR DESCRIPTION
It looked like this:

Firefox:
![firefoxold](https://user-images.githubusercontent.com/5622899/46584213-f018c500-ca36-11e8-8644-143dfbcf61b8.png)

Chrome:
![chromeold](https://user-images.githubusercontent.com/5622899/46584220-fd35b400-ca36-11e8-97d1-a6c55cb423db.png)


Now it looks like this:
![screenshot from 2018-10-07 13-41-57](https://user-images.githubusercontent.com/5622899/46584237-1f2f3680-ca37-11e8-8518-28a55865b496.png)

I removed the gradient because it was not used in other places of the page, so I replaced it with a solid color, with just a bit of border-radius, with the same colors as the rest of the page.

Because, why not.